### PR TITLE
added some error handling and use of `dirs::config_dir`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dirs = "4.0.0"
 ic-agent = "0.10.0"
 ic-utils = "0.10.0"
+thiserror = "1.0.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,7 @@ name = "ic-helpers"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 dirs = "4.0.0"
 ic-agent = "0.10.0"
-ic-utils = "0.10.0"
 thiserror = "1.0.30"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,13 @@
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Agent error: {0}")]
+    Agent(#[from] ic_agent::agent::agent_error::AgentError),
+
+    #[error("Identity error: {0}")]
+    Ident(#[from] ic_agent::identity::PemError),
+
+    #[error("Failed to get config directory")]
+    MissingConfig,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub mod utils;
 mod errors;
+pub mod utils;
 
-pub use errors::{Result, Error};
+pub use errors::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,4 @@
 pub mod utils;
+mod errors;
+
+pub use errors::{Result, Error};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
+
+use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
 use ic_agent::identity::BasicIdentity;
 use ic_agent::Agent;
-use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
 
 use crate::Result;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
-use std::path::{Path, PathBuf};
+//! Utilities for testing
+use std::path::Path;
 
 use ic_agent::agent::http_transport::ReqwestHttpReplicaV2Transport;
 use ic_agent::identity::BasicIdentity;
@@ -6,21 +7,27 @@ use ic_agent::Agent;
 
 use crate::Result;
 
-fn get_identity_path(account_name: impl AsRef<Path>) -> Result<PathBuf> {
-    let mut path = dirs::config_dir().ok_or(crate::Error::MissingConfig)?;
-    path.push("dfx/identity");
-    path.push(account_name);
-    path.push("identity.pem");
-    Ok(path)
-}
+/// Get the identity for an account.
+/// This is useful for testing.
+pub fn get_identity(account_name: impl AsRef<Path>) -> Result<BasicIdentity> {
+    let mut ident_path = dirs::config_dir().ok_or(crate::Error::MissingConfig)?;
+    ident_path.push("dfx/identity");
+    ident_path.push(account_name);
+    ident_path.push("identity.pem");
 
-pub fn get_identity(account_name: impl AsRef<str>) -> Result<BasicIdentity> {
-    let ident_path = get_identity_path(account_name.as_ref())?;
     let identity = BasicIdentity::from_pem_file(ident_path)?;
     Ok(identity)
 }
 
-pub async fn get_agent(name: impl AsRef<str>, url: impl Into<String>) -> Result<Agent> {
+/// Get an agent by name.
+/// This is assuming there is an agent identity available.
+///
+/// ```text
+/// # Clone the identity project first
+/// mkdir -p ~/.config/dfx/identity/
+/// cp -Rn ./identity/.config/dfx/identity/* ~/.config/dfx/identity/
+/// ```
+pub async fn get_agent(name: impl AsRef<Path>, url: impl Into<String>) -> Result<Agent> {
     let identity = get_identity(name)?;
 
     let transport = ReqwestHttpReplicaV2Transport::create(url)?;


### PR DESCRIPTION
Use `config_dir` instead of getting "HOME" and then attaching the ".config" dir.
This way it will theoretically work on MacOS and Windows as well.

Made the functions more generic.

Added "dirs" and "thiserror" for directory handling and error handling
Created a custom error type and added error handling

Added proper error handling here. `unwrap` and `expect` can still be used wherever we use this library but we will have a better overview of what is happening when creating tests etc.

On making functions more generic:

It makes sense to take `impl Into<String>`, `impl AsRef<str>` etc. as it makes it possible to call the functions with either a `String` or a `&str`.

If a function becomes a lot larger we can write wrappers around them if we want to cut down on the amount of code generated, however that's not a problem here.