### PR TITLE
[CPROD-353] Adds ic-storage crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,5 +2,7 @@
 members = [
   "test-utils",
   "canisters",
+  "ic-storage",
+  "ic-storage/ic-storage-derive",
 ]
 

--- a/ic-storage/Cargo.toml
+++ b/ic-storage/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "ic-storage"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ic-storage-derive = {path = "ic-storage-derive"}

--- a/ic-storage/ic-storage-derive/Cargo.toml
+++ b/ic-storage/ic-storage-derive/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ic-storage-derive"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+proc-macro2 = "1.0.34"
+quote = "1.0.10"
+syn = { version = "1.0.82", features = ["full"] }

--- a/ic-storage/ic-storage-derive/src/lib.rs
+++ b/ic-storage/ic-storage-derive/src/lib.rs
@@ -1,0 +1,23 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::DeriveInput;
+
+#[proc_macro_derive(IcStorage)]
+pub fn derive_ic_storage(input: TokenStream) -> TokenStream {
+    let DeriveInput { ident, .. } = syn::parse_macro_input!(input);
+    let output = quote::quote! {
+        impl ::ic_storage::IcStorage for #ident {
+            fn get() -> ::std::rc::Rc<::std::cell::RefCell<Self>> {
+                use ::std::rc::Rc;
+                thread_local! {
+                    static store: ::std::rc::Rc<::std::cell::RefCell<#ident>> = ::std::rc::Rc::new(::std::cell::RefCell::new(#ident::default()));
+                }
+
+                store.with(|v| v.clone())
+            }
+        }
+    };
+
+    output.into()
+}

--- a/ic-storage/src/lib.rs
+++ b/ic-storage/src/lib.rs
@@ -1,0 +1,56 @@
+//! This crate provides a safe way to use canister state. At the moment, ic_cdk storage has an
+//! implementation bug, that make memory corruption possible (https://github.com/dfinity/cdk-rs/issues/73).
+//!
+//! To use storage with this crate, use [IcStorage] derive macro. Structs, that use it must also
+//! implement `Default` trait.
+//!
+//! ```
+//! use ic_storage::IcStorage;
+//! use std::rc::Rc;
+//! use std::cell::RefCell;
+//!
+//! #[derive(IcStorage, Default)]
+//! struct MyCanisterState {
+//!     value: u32,
+//! }
+//!
+//! let local_state: Rc<RefCell<MyCanisterState>> = MyCanisterState::get();
+//! println!("Current value: {}", local_state.borrow().value);
+//! RefCell::borrow_mut(&*local_state).value = 42;
+//! ```
+//!
+//! *IMPORTANT*: `IcStorage` only provides local canister state storage. It DOES NOT in any way
+//! related to the stable storage. In order to preserve the canister data between canister
+//! upgrades you must use `ic_cdk::storage::stable_save()` and `ic_cdk::storage::stable_restore()`.
+//! Any state that is not saved and restored with these methods will be lost when the canister
+//! is upgraded. On the details how to do it, check out the Rust coding conventions page in
+//! confluence.
+//!
+//! # Ways to use `IcStorage`
+//!
+//! There are two approaches for managing canister state:
+//!
+//! 1. You can have one big structure that contains all the state. In this case only this structure
+//!    must implement `IcStorage`. This approach makes it easier to take care for storing the state
+//!    in the stable storage on upgrade, and just in general it's easier to manage the state when
+//!    it's all in one place. On the other hand, it means that you can have only one mutable
+//!    reference to this state during entire call, so you'll have to retrieve the state at the
+//!    call entry point, and then call all inner functions with the state reference as argument.
+//!    When there are many different parts of the state and they are not tightly connected to
+//!    each other, it can become somewhat cumbersome.
+//!
+//! 2. You can have different types implementing `IcStorage`, thus making them completely independent.
+//!    This approach is more flexible, especially for larger states, but special care must be taken
+//!    not to forget any part of the state in the upgrade methods.
+
+use std::rc::Rc;
+use std::cell::RefCell;
+
+pub use ic_storage_derive::IcStorage;
+
+/// Type that is stored in local canister state.
+pub trait IcStorage {
+    /// Returns the reference to the canister state. `RefCell` is used to prevent memory corruption
+    /// for the state is the same object for all calls.
+    fn get() -> Rc<RefCell<Self>>;
+}

--- a/ic-storage/tests/derive.rs
+++ b/ic-storage/tests/derive.rs
@@ -1,0 +1,12 @@
+use ic_storage::IcStorage;
+
+#[derive(IcStorage, Default)]
+struct TestStorage {
+    val: u32,
+}
+
+#[test]
+fn test_storage_derive_macro() {
+    let storage = TestStorage::get();
+    assert_eq!(storage.borrow().val, 0);
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,31 @@
+use std::any::{Any, TypeId};
+use std::collections::BTreeMap;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+type StorageTree = BTreeMap<TypeId, Box<dyn Any>>;
+
+static mut STORAGE: Option<Rc<RefCell<Storage>>> = None;
+
+pub struct Storage(StorageTree);
+
+impl Storage {
+    fn load() -> Rc<RefCell<Self>> {
+        unsafe {
+            if STORAGE.is_none() {
+                STORAGE = Some(Rc::new(RefCell::new(Self(StorageTree::new()))));
+            }
+
+            STORAGE.as_ref().unwrap().clone()
+        }
+    }
+
+    fn get_mut<T: Sized + Default + 'static>(&mut self) -> &mut T {
+        let type_id = std::any::TypeId::of::<T>();
+        self.0
+            .entry(type_id)
+            .or_insert_with(|| Box::new(T::default()))
+            .downcast_mut()
+            .expect("Unexpected value of invalid type.")
+    }
+}


### PR DESCRIPTION
This PR adds a derive macro for `IcStorage` trait, that provides a safe and simple way to use canister local storage.