### PR TITLE
[CPROD-370] Refactoring of factory state management

### DIFF
--- a/canisters/src/factory/api.rs
+++ b/canisters/src/factory/api.rs
@@ -1,77 +1,97 @@
 #[macro_export]
-macro_rules! init_api {
-    ( $state:ident ) => {
-        use ic_helpers::is20::IS20PrincipalExt;
+macro_rules! init_factory_api {
+    ( $state:ident, $bytecode:expr ) => {
+        // Add this block not to pollute caller context with our use.
+        mod __factory_api {
+            use super::$state;
+            use ::canisters::is20::IS20PrincipalExt;
+            use ::ic_storage::IcStorage;
 
-        /// Returns the checksum of a wasm module in hex representation.
-        #[query(name = "get_checksum")]
-        #[candid::candid_method(query, rename = "get_checksum")]
-        async fn get_checksum() -> String {
-            $state::get().factory.checksum.to_string()
-        }
+            /// Returns the checksum of a wasm module in hex representation.
+            #[::ic_cdk_macros::query(name = "get_checksum")]
+            #[::candid::candid_method(query, rename = "get_checksum")]
+            async fn get_checksum() -> String {
+                $state::get().borrow().factory.checksum.to_string()
+            }
 
-        /// Returns the cycles balances.
-        /// If principal == None then cycles balances of factory is returned,
-        /// otherwise, cycles balances of `principal` is returned.
-        /// If `principal` does not exists, `None` is returned.
-        #[update(name = "get_cycles")]
-        #[candid::candid_method(update, rename = "get_cycles")]
-        async fn get_cycles(principal: Option<candid::Principal>) -> Option<candid::Nat> {
-            Some(if let Some(principal) = principal {
-                ic_helpers::management::Canister::from(principal)
-                    .status()
-                    .await
-                    .map(|status| status.cycles)
-                    .ok()?
-            } else {
-                candid::Principal::cycles()
-            })
-        }
+            /// Returns the cycles balances.
+            /// If principal == None then cycles balances of factory is returned,
+            /// otherwise, cycles balances of `principal` is returned.
+            /// If `principal` does not exists, `None` is returned.
+            #[::ic_cdk_macros::update(name = "get_cycles")]
+            #[::candid::candid_method(update, rename = "get_cycles")]
+            async fn get_cycles(principal: Option<::candid::Principal>) -> Option<::candid::Nat> {
+                Some(if let Some(principal) = principal {
+                    ::canisters::management::Canister::from(principal)
+                        .status()
+                        .await
+                        .map(|status| status.cycles)
+                        .ok()?
+                } else {
+                    ::candid::Principal::cycles()
+                })
+            }
 
-        /// Accepts cycles from other canisters (the caller).
-        /// Other canisters can send cycles using `api::call::call_with_payment` method.
-        /// Returns the actual amount of accepted cycles.
-        #[update(name = "top_up")]
-        #[candid::candid_method(update, rename = "top_up")]
-        async fn top_up() -> u64 {
-            ic_helpers::management::Canister::accept_cycles()
-        }
+            /// Accepts cycles from other canisters (the caller).
+            /// Other canisters can send cycles using `api::call::call_with_payment` method.
+            /// Returns the actual amount of accepted cycles.
+            #[::ic_cdk_macros::update(name = "top_up")]
+            #[::candid::candid_method(update, rename = "top_up")]
+            async fn top_up() -> u64 {
+                ::canisters::management::Canister::accept_cycles()
+            }
 
-        /// Upgrades canisters and returns a list of outdated canisters.
-        #[update(name = "upgrade")]
-        #[candid::candid_method(update, rename = "upgrade")]
-        async fn upgrade() -> Vec<candid::Principal> {
-            candid::Principal::check_access($state::get().admin);
-            $state::get().factory.upgrade($state::wasm()).await
-        }
+            /// Upgrades canisters and returns a list of outdated canisters.
+            #[::ic_cdk_macros::update(name = "upgrade")]
+            #[::candid::candid_method(update, rename = "upgrade")]
+            async fn upgrade() -> Vec<::candid::Principal> {
+                // TODO: At the moment we do not do any security checks for this method, for even if there's
+                // nothing to upgrade, it will just check all canisters and do nothing else.
+                // Later, we should add here (and in create_canister methods) a cycle check,
+                // to make the caller to pay for the execution of this method.
 
-        /// Sets the admin principal.
-        #[update(name = "set_admin")]
-        #[candid::candid_method(update, rename = "set_admin")]
-        async fn set_admin(admin: candid::Principal) {
-            candid::Principal::check_access($state::get().admin);
-            $state::get().admin = admin;
-        }
+                let state = $state::get();
+                let canisters = state.borrow().factory.canisters.clone();
+                let curr_version = state.borrow().factory.checksum.version;
+                let mut outdated_canisters = vec![];
 
-        /// Returns the current version of canister.
-        #[query(name = "version")]
-        #[candid::candid_method(query, rename = "version")]
-        async fn version() -> String {
-            env!("CARGO_PKG_VERSION").to_string()
-        }
+                for (key, canister) in canisters {
+                    if canister.version() == curr_version {
+                        continue;
+                    }
 
-        /// Returns the length of canisters created by the factory.
-        #[query(name = "length")]
-        #[candid::candid_method(query, rename = "length")]
-        async fn length() -> usize {
-            $state::get().factory.len()
-        }
+                    let upgrader = state.borrow().factory.upgrade(&canister, $bytecode);
+                    match upgrader.await {
+                        Ok(upgraded) => {
+                            state.borrow_mut().factory.register_upgraded(&key, upgraded)
+                        }
+                        Err(_) => outdated_canisters.push(canister.identity()),
+                    }
+                }
 
-        /// Returns a vector of all canisters cretaed by the factory.
-        #[query(name = "get_all")]
-        #[candid::candid_method(query, rename = "get_all")]
-        async fn get_all() -> Vec<candid::Principal> {
-            $state::get().factory.all()
+                outdated_canisters
+            }
+
+            /// Returns the current version of canister.
+            #[::ic_cdk_macros::query(name = "version")]
+            #[::candid::candid_method(query, rename = "version")]
+            async fn version() -> String {
+                env!("CARGO_PKG_VERSION").to_string()
+            }
+
+            /// Returns the length of canisters created by the factory.
+            #[::ic_cdk_macros::query(name = "length")]
+            #[::candid::candid_method(query, rename = "length")]
+            async fn length() -> usize {
+                $state::get().borrow().factory.len()
+            }
+
+            /// Returns a vector of all canisters cretaed by the factory.
+            #[::ic_cdk_macros::query(name = "get_all")]
+            #[::candid::candid_method(query, rename = "get_all")]
+            async fn get_all() -> Vec<candid::Principal> {
+                $state::get().borrow().factory.all()
+            }
         }
     };
 }

--- a/canisters/src/is20/principal_ext.rs
+++ b/canisters/src/is20/principal_ext.rs
@@ -1,6 +1,6 @@
 use crate::management::{Canister, InstallCodeMode};
 use async_trait::async_trait;
-use candid::{decode_args, encode_args, CandidType, Nat, Principal};
+use candid::{encode_args, CandidType, Nat, Principal};
 use ic_cdk::api;
 use ic_cdk::api::call::CallResult;
 use num_traits::cast::ToPrimitive;

--- a/canisters/src/pair/types.rs
+++ b/canisters/src/pair/types.rs
@@ -37,3 +37,9 @@ impl TokenInfo {
         }
     }
 }
+
+impl Default for TokenInfo {
+    fn default() -> Self {
+        Self::empty()
+    }
+}


### PR DESCRIPTION
* Remove `State` struct completely from this crate. Instead, it expects the macro users to provide `State` that implements `IcStorage`. This is done to remove usage of unsafe `static mut` and make it more flexible for the crate consumers.
* Instead of `init_state` macro `impl_factory_state_management` is added. It provides convenient way to implement stable storage functions for the state object. It does not include `#init` method though, so it should be implemented by hand.
* Removes notion of `admin` and all the methods, related to it. Not all consumers of the factory helpers require admin checks. Also, upgrade method, the only method that used `admin` value inside ic_helpers, does not really need the admin check. Instead, we should probably add cycles check and consuming in the upgrade method to make the caller to pay for the upgrade, not the factory itself.
* Changes implementation of `create` and `upgrade` methods to be async-safe. To do it, we make these methods return futures that can be awaited on after the borrowed state is dropped. Otherwise, memory access conflict is possible in case of concurrent requests to these and other methods.
* Rename `init_api` macro to `init_factory_api` because when using this macro, the namespace is not used, so it's not obvious that the macro is related to the factory. Also, fixed the namespaces in the macro, and renamed `ic_helpers` to `canisters`, because that's the name of the crate. Probably, it's better to rename the crate to `ic_helpers` instead, especially if we have an idea to publish it some date to crates.io.

To check out, how this refactoring is used, check out these PRs:
* https://github.com/infinity-swap/IS20/pull/22/files
* https://github.com/infinity-swap/v1-amm/pull/67