### PR TITLE
Added upgradable types to stable storage

### DIFF
--- a/ic-storage/Cargo.toml
+++ b/ic-storage/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 ic-storage-derive = {path = "ic-storage-derive"}
+thiserror = "1.0"
+ic-cdk = "0.3"
+serde = { version = "1.0", features = ["derive"] }

--- a/ic-storage/src/errors.rs
+++ b/ic-storage/src/errors.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+use ic_cdk::api::stable::StableMemoryError;
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Insufficient space available")]
+    InsufficientSpace,
+    
+    #[error("Stable memory error")]
+    StableMemory,
+
+    #[error("Attempted downgrade, or trying to load a version older than what is currently stored")]
+    AttemptedDowngrade,
+
+    #[error("Candid error: {0}")]
+    Candid(#[from] ic_cdk::export::candid::Error),
+}
+
+// Required because `StableMemoryError` doesn't implement Debug
+impl From<StableMemoryError> for Error {
+    fn from(_: StableMemoryError) -> Self {
+        Self::StableMemory
+    }
+}

--- a/ic-storage/src/lib.rs
+++ b/ic-storage/src/lib.rs
@@ -1,8 +1,9 @@
-//! This crate provides a safe way to use canister state. At the moment, ic_cdk storage has an
-//! implementation bug, that make memory corruption possible (https://github.com/dfinity/cdk-rs/issues/73).
+//! This crate provides a safe way to use canister state, as well as versioned storage. At the moment, ic_cdk storage has an
+//! implementation bug, that make memory corruption possible <https://github.com/dfinity/cdk-rs/issues/73>.
 //!
-//! To use storage with this crate, use [IcStorage] derive macro. Structs, that use it must also
-//! implement `Default` trait.
+//! * For in memory storage use [`IcStorage`]. 
+//!   Structs that derive [`IcStorage`] must also implement `std::fmt::Default`.
+//! * For versioned storage see [`crate::stable`].
 //!
 //! ```
 //! use ic_storage::IcStorage;
@@ -39,20 +40,23 @@
 //! ```
 //!
 //! *IMPORTANT*: `IcStorage` only provides local canister state storage. It DOES NOT in any way
-//! related to the stable storage. In order to preserve the canister data between canister
-//! upgrades you must use `ic_cdk::storage::stable_save()` and `ic_cdk::storage::stable_restore()`.
-//! Any state that is not saved and restored with these methods will be lost when the canister
-//! is upgraded. On the details how to do it, check out the Rust coding conventions page in
-//! confluence.
+//! related to the stable storage. See [`crate::stable`] for stable storage. 
+//!
+//! In order to preserve the canister data between canister upgrades you should 
+//! use either `ic_cdk::storage::stable_save()` and `ic_cdk::storage::stable_restore()`, 
+//! or [`crate::stable::read`] / [`crate::stable::write`].
+//!
+//! Any state that is not saved or restored using these methods will be lost if the canister
+//! is upgraded. 
 //!
 //! # Ways to use `IcStorage`
 //!
 //! There are two approaches for managing canister state:
 //!
 //! 1. You can have one big structure that contains all the state. In this case only this structure
-//!    must implement `IcStorage`. This approach makes it easier to take care for storing the state
-//!    in the stable storage on upgrade, and just in general it's easier to manage the state when
-//!    it's all in one place. On the other hand, it means that you can have only one mutable
+//!    must implement `IcStorage`. This approach makes it easier to take care of storing the state
+//!    in the stable storage on upgrade, and it's easier to manage the state when
+//!    it's all in one place. On the other hand, it means that you can only have one mutable
 //!    reference to this state during entire call, so you'll have to retrieve the state at the
 //!    call entry point, and then call all inner functions with the state reference as argument.
 //!    When there are many different parts of the state and they are not tightly connected to
@@ -60,12 +64,20 @@
 //!
 //! 2. You can have different types implementing `IcStorage`, thus making them completely independent.
 //!    This approach is more flexible, especially for larger states, but special care must be taken
-//!    not to forget any part of the state in the upgrade methods.
+//!    not to forget any part of the state in the upgrade methods. Reading and writing to and from
+//!    stable storage would require that everything that should be saved is passed as a single data
+//!    type (e.g a tuple or a custom struct), as writing to stable storage overwrites what is
+//!    currently there (meaning if we write one struct and then another, the second would overwrite
+//!    the first).
 
 use std::cell::RefCell;
 use std::rc::Rc;
 
 pub use ic_storage_derive::IcStorage;
+
+pub mod stable;
+pub mod errors;
+pub use errors::{Error, Result};
 
 /// Type that is stored in local canister state.
 pub trait IcStorage {

--- a/ic-storage/src/stable.rs
+++ b/ic-storage/src/stable.rs
@@ -1,0 +1,340 @@
+#![deny(missing_docs)]
+//! This module provides versioned data for stable storage.
+//!
+//! This makes it possible to change the type that is serialized and written to stable storage.
+//!
+//! Versioning happens between types, not data.
+//! This means that any data written to stable storage through the `write` function
+//! will overwrite whatever data was stored there from before.
+//!
+//! To be able to read and write a struct from stable storage
+//! using these functions, the struct needs to implement the [`Versioned`] trait 
+//! (which in turn requires [`Deserialize`] and [`CandidType`])
+//!
+//! How is the data stored in stable storage?
+//!
+//! The first four bytes written is the version number as a [`u32`],
+//! the remaining bytes represent the struct.
+//! ```text
+//!  0 1 2 3 ...
+//! +-+-+-+-+-+-+-+-+-+
+//! |V|E|R|S|  Struct |
+//! +-+-+-+-+-+-+-+-+-+
+//! ```
+//!
+//! ## How to use this
+//!
+//! Write the first version to stable storage using `write`
+//! on the `#[init]` method of the canister.
+//!
+//! ```ignore
+//! #[init]
+//! fn init() {
+//!     let first_version = get_first_version();
+//!     if let Err(e) = write(&first_version) {
+//!         ic_cdk::eprintln!("Failed to write to stable storage: {}", e);
+//!     }
+//! }
+//!
+//! ```
+//!
+//! Once a new version of the struct has been created set the `Previous` associated type
+//! to the previous version of the struct.
+//!
+//! ```ignore
+//! impl Versioned for NewVersion {
+//!     type Previous = OldVersion;
+//!     ...
+//! }
+//! ```
+//!
+//! Make sure the previous version is written to stable storage before the upgrade.
+//! On `post_upgrade` the new version can be populated from the previous version.
+//!
+//! ```ignore
+//! #[pre_upgrade]
+//! fn pre_upgrade() {
+//!     let first_version: FirstVersion = get_first_version();
+//!     write(first_version).unwrap();
+//! }
+//!
+//! #[post_upgrade]
+//! fn post_upgrade() {
+//!     let second_version = read::<SecondVersion>().unwrap();
+//! }
+//! ```
+//!
+//! The old version still has to exist, this can be managed by numbering modules, 
+//! e.g `crate::v1::MyData`, `crate::v2::MyData`.
+//!
+//! Upgrades can span multiple versions, making it possible to upgrade from v1 to v3 in one go.
+//!
+//! **Note**: trying to load a version older than what is currently stored will result in an `AttemptedDowngrade` error.
+//!
+//! ## Examples
+//!
+//! ### Creating a versioned struct
+//! ```
+//! use ic_storage::stable::Versioned;
+//! use ic_cdk::export::candid::CandidType;
+//! use serde::Deserialize;
+//!
+//! #[derive(Debug, Deserialize, CandidType)]
+//! struct First(usize, usize);
+//!
+//! impl Versioned for First {
+//!     type Previous = ();
+//!
+//!     fn version() -> u32 { 1 }
+//!
+//!     fn upgrade((): ()) -> Self {
+//!         First(0, 0)
+//!     }
+//! }
+//!
+//! #[derive(Debug, Deserialize, CandidType)]
+//! struct Second(String);
+//!
+//! impl Versioned for Second {
+//!     type Previous = First;
+//!
+//!     fn version() -> u32 { 2 }
+//!
+//!     fn upgrade(previous: Self::Previous) -> Self {
+//!         Second(format!("{}, {}", previous.0, previous.1))
+//!     }
+//! }
+//! ```
+//!
+//! ## Reading
+//!
+//! Read the latest implementation from stable memory.
+//! If there is a previous version stored, this version will be upgraded.
+//!
+//! ```
+//! use ic_storage::stable::{Versioned, read};
+//! # use ic_cdk::export::candid::CandidType;
+//! # use serde::Deserialize;
+//!
+//! # #[derive(Debug, Deserialize, CandidType)]
+//! # struct First(usize, usize);
+//! # impl Versioned for First {
+//! #     type Previous = ();
+//! #     fn version() -> u32 { 1 }
+//! #     fn upgrade((): ()) -> Self {
+//! #         First(0, 0)
+//! #     }
+//! # }
+//! # #[derive(Debug, Deserialize, CandidType)]
+//! # struct Second(String);
+//! # impl Versioned for Second {
+//! #     type Previous = First;
+//! #     fn version() -> u32 { 2 }
+//! #     fn upgrade(previous: Self::Previous) -> Self {
+//! #         Self(format!("{}, {}", previous.0, previous.1))
+//! #     }
+//! # }
+//! // #[post_upgrade]
+//! fn post_upgrade_canister() {
+//!     let second = read::<Second>().unwrap();
+//! }
+//!
+//! ```
+//!
+//! ## Writing
+//! 
+//! Write the current version to stable storage.
+//!
+//! ```
+//! use ic_storage::stable::{Versioned, write};
+//! # use ic_cdk::export::candid::CandidType;
+//! # use serde::Deserialize;
+//!
+//! # #[derive(Debug, Deserialize, CandidType)]
+//! # struct First(usize, usize);
+//! # impl Versioned for First {
+//! #     type Previous = ();
+//! #     fn version() -> u32 { 1 }
+//! #     fn upgrade((): ()) -> Self {
+//! #         First(0, 0)
+//! #     }
+//! # }
+//! # fn get_first() -> First { First(1, 2) }
+//! // #[pre_upgrade]
+//! fn pre_upgrade_canister() {
+//!     let first: First = get_first();
+//!     write(&first).unwrap();
+//! }
+//! ```
+use std::mem::size_of;
+
+use ic_cdk::api::stable::{stable_bytes, stable_read, stable_size, StableWriter};
+use ic_cdk::export::candid::de::IDLDeserialize;
+use ic_cdk::export::candid::ser::IDLBuilder;
+use ic_cdk::export::candid::types::CandidType;
+use serde::Deserialize;
+
+use crate::{Error, Result};
+
+const VERSION_SIZE: usize = size_of::<u32>();
+
+/// Versioned data that can be written to, and read from stable storage.
+pub trait Versioned: for<'de> Deserialize<'de> + CandidType {
+    /// The previous version of this data.
+    /// If there is no previous version specify a unit (`()`).
+    /// This is required until defaults for associated types are stable.
+    ///
+    /// A unit has a version number of zero, and a `Previous` type of a unit,
+    /// which means it's not possible to upgrade a unit from anything but it self,
+    /// and calling `upgrade` will simply return `()`.
+    type Previous: Versioned;
+
+    /// The version of the data
+    fn version() -> u32;
+
+    /// Upgrade to this version from the previous version.
+    fn upgrade(previous: Self::Previous) -> Self;
+}
+
+// -----------------------------------------------------------------------------
+//     - Versioned implementation for a unit -
+//     This is useful
+// -----------------------------------------------------------------------------
+impl Versioned for () {
+    type Previous = ();
+
+    fn version() -> u32 {
+        0
+    }
+
+    fn upgrade((): ()) -> Self {}
+}
+
+/// Load a [`Versioned`] from stable storage.
+pub fn read<T: Versioned>() -> Result<T> {
+    let mut version = [0u8; VERSION_SIZE];
+    if ((stable_size() << 16) as usize) < version.len() {
+        return Err(Error::InsufficientSpace);
+    }
+
+    stable_read(0, &mut version);
+    let version = u32::from_ne_bytes(version);
+    if T::version() < version {
+        return Err(Error::AttemptedDowngrade);
+    }
+
+    let bytes = stable_bytes();
+    let res = recursive_upgrade::<T>(version, &bytes[VERSION_SIZE..])?;
+    Ok(res)
+}
+
+/// Write a [`Versioned`] to stable storage.
+/// This will overwrite anything that was previously stored.
+pub fn write<T: Versioned>(payload: &T) -> Result<()> {
+    let version = T::version().to_ne_bytes();
+    let mut writer = StableWriter::default();
+
+    // Write the version number to the first four bytes.
+    // There is no point in checking that the four bytes were actually
+    // written as one would normally do with with an `io::Write`,
+    // as the failure point lies in growing the stable storage,
+    // and the usize returned from the `write` call isn't actually the number
+    // of bytes written, but rather the size of the slice that was passed in.
+    writer.write(&version)?;
+
+    // Serialize and write the `Versioned`
+    let mut serializer = IDLBuilder::new();
+    serializer.arg(payload)?.serialize(writer)?;
+
+    Ok(())
+}
+
+// -----------------------------------------------------------------------------
+//     - Recursively upgrade -
+//     Recursively upgrade a `Versioned`.
+// -----------------------------------------------------------------------------
+fn recursive_upgrade<T: Versioned>(version: u32, bytes: &[u8]) -> Result<T> {
+    if version == T::version() {
+        let mut de = IDLDeserialize::new(bytes)?;
+        let res = de.get_value()?;
+        Ok(res)
+    } else {
+        let val = recursive_upgrade::<T::Previous>(version, bytes)?;
+        Ok(T::upgrade(val))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use ic_cdk::export::candid::CandidType;
+
+    #[derive(Debug, CandidType, Deserialize)]
+    struct Version1(u32);
+    #[derive(Debug, CandidType, Deserialize)]
+    struct Version2(u32, u32);
+    #[derive(Debug, CandidType, Deserialize)]
+    struct Version3(u32, u32, u32);
+
+    impl Versioned for Version1 {
+        type Previous = ();
+        fn version() -> u32 {
+            1
+        }
+
+        fn upgrade(_: Self::Previous) -> Self {
+            Self(0)
+        }
+    }
+
+    impl Versioned for Version2 {
+        type Previous = Version1;
+        fn version() -> u32 {
+            2
+        }
+
+        fn upgrade(previous: Self::Previous) -> Self {
+            Self(previous.0, 5)
+        }
+    }
+
+    impl Versioned for Version3 {
+        type Previous = Version2;
+        fn version() -> u32 {
+            3
+        }
+
+        fn upgrade(previous: Self::Previous) -> Self {
+            Self(previous.0, previous.1, 900)
+        }
+    }
+
+    #[test]
+    fn upgrade_versions() {
+        let mut v1_bytes = vec![];
+        let mut serializer = IDLBuilder::new();
+        serializer
+            .arg(&Version1(1))
+            .unwrap()
+            .serialize(&mut v1_bytes)
+            .unwrap();
+        let v2 = super::recursive_upgrade::<Version2>(1, &v1_bytes).unwrap();
+        let Version2(a, b) = v2;
+        assert_eq!((a, b), (1, 5));
+    }
+
+    #[test]
+    fn upgrade_across_two_versions() {
+        let mut v1_bytes = vec![];
+        let mut serializer = IDLBuilder::new();
+        serializer
+            .arg(&Version1(1))
+            .unwrap()
+            .serialize(&mut v1_bytes)
+            .unwrap();
+        let v3 = super::recursive_upgrade::<Version3>(1, &v1_bytes).unwrap();
+        let Version3(a, b, c) = v3;
+        assert_eq!((a, b, c), (1, 5, 900));
+    }
+
+}


### PR DESCRIPTION
Downgrades are currently not possible but could be implemented if that's a requirement.

Since data loss can ensue if anything is incorrect here let me know if anything is unclear or if there is something missing.

I have tested this locally by creating and upgrading structs but "works on my machine" is not indicative of "works perfectly".

If the documentation is unclear let me know.
This could benefit from more tests, perhaps using a mock of stable storage?

Once this is approved we can start by implementing this for canisters that should be up-gradable. 