### PR TITLE
Fix upgrades

### DIFF
--- a/ic-canister/ic-canister-macros/src/derive.rs
+++ b/ic-canister/ic-canister-macros/src/derive.rs
@@ -197,7 +197,7 @@ fn expand_upgrade_methods(
         quote! { &* #name.borrow(), },
     );
 
-    let field_assignment = quote! { #field_type::get().replace(#name); };
+    let field_assignment = quote! { self. #name.replace(#name); };
 
     quote! {
         impl #struct_name {

--- a/ic-storage/src/stable.rs
+++ b/ic-storage/src/stable.rs
@@ -120,10 +120,10 @@
 //! ```
 use std::mem::size_of;
 
-#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
 use crate::testing::{stable_bytes, stable_read, stable_size, StableWriter};
 
-#[cfg(not(test))]
+#[cfg(target_arch = "wasm32")]
 use ic_cdk::api::stable::{stable_bytes, stable_read, stable_size, StableWriter};
 
 use ic_cdk::export::candid::de::IDLDeserialize;


### PR DESCRIPTION
* Change the canister upgrade functions to use an instance.
* Fix `trap` (had incorrect args)
* Check architecture rather than test for local testing functions