### PR TITLE
[WPROD-53] Add random principal ids for the Canister generated structs

### DIFF
--- a/ic-canister/ic-canister-macros/Cargo.toml
+++ b/ic-canister/ic-canister-macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+rand = "0.8.5"
 proc-macro2 = "1.0"
 ic-cdk = "0.3"
 lazy_static = "1"

--- a/ic-canister/ic-canister-macros/src/derive.rs
+++ b/ic-canister/ic-canister-macros/src/derive.rs
@@ -137,7 +137,7 @@ pub fn derive_canister(input: TokenStream) -> TokenStream {
         #[cfg(not(target_arch = "wasm32"))]
         thread_local! {
             static CANISTERS: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<Principal, #name>>> = ::std::rc::Rc::new(::std::cell::RefCell::new(::std::collections::HashMap::new()));
-            static __NEXT_ID: ::std::sync::atomic::AtomicU64 = 5.into();
+            static __NEXT_ID: ::std::sync::atomic::AtomicU64 = rand::random::<u64>().into();
         }
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -166,7 +166,7 @@ pub fn derive_canister(input: TokenStream) -> TokenStream {
 
             #[cfg(not(target_arch = "wasm32"))]
             fn from_principal(principal: ::ic_cdk::export::Principal) -> Self {
-                let registry: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<::ic_cdk::export::Principal, #name>>>  = CANISTERS.with(|v| v.clone());
+                let registry: ::std::rc::Rc<::std::cell::RefCell<::std::collections::HashMap<::ic_cdk::export::Principal, #name>>> = CANISTERS.with(|v| v.clone());
                 let mut registry = ::std::cell::RefCell::borrow_mut(&registry);
                 registry.get(&principal).expect(&format!("canister of type {} with principal {} is not registered", ::std::any::type_name::<Self>(), principal)).clone()
             }

--- a/ic-canister/tests/canister_a/Cargo.toml
+++ b/ic-canister/tests/canister_a/Cargo.toml
@@ -16,4 +16,5 @@ ic-cdk = "0.3"
 ic-cdk-macros = "0.3"
 ic-storage = {path = "../../../ic-storage"}
 ic-canister = {path = "../../ic-canister"}
+rand = "0.8.5"
 serde = "1.0"

--- a/ic-canister/tests/canister_b/Cargo.toml
+++ b/ic-canister/tests/canister_b/Cargo.toml
@@ -10,6 +10,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 ic-cdk = "0.3"
+rand = "0.8.5"
 canister_a = {path = "../canister_a"}
 ic-storage = {path = "../../../ic-storage"}
 ic-canister = {path = "../../ic-canister"}


### PR DESCRIPTION
This had names clashing if you create token canisters like in the example below
```rust
mod Token0 {
    #[derive(Clone, Canister)]
    pub struct Token0Canister {
        #[id]
        principal: Principal,
    }
}

mod Token1 {
    #[derive(Clone, Canister)]
    pub struct Token1Canister {
        #[id]
        principal: Principal,
    }
}
```