### PR TITLE
[CPROD-753] Update ic dependency, refactoring

### DIFF
--- a/ic-canister/ic-canister-macros/src/canister_call.rs
+++ b/ic-canister/ic-canister-macros/src/canister_call.rs
@@ -15,8 +15,15 @@ struct CanisterCall {
 impl Parse for CanisterCall {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let method_call = input.parse()?;
-        input.parse::<Token![,]>()?;
-        let response_type = input.parse()?;
+        input.parse::<Token![,]>().map_err(|e| {
+            syn::Error::new(
+                e.span(),
+                "second parameter is missing, expecting the method return type",
+            )
+        })?;
+        let response_type = input
+            .parse()
+            .map_err(|e| syn::Error::new(e.span(), "failed to parse method response type"))?;
         let cycles = if input.peek(Token![,]) {
             input.parse::<Token![,]>()?;
             let cycles = input.parse()?;

--- a/ic-canister/ic-canister-macros/src/derive.rs
+++ b/ic-canister/ic-canister-macros/src/derive.rs
@@ -152,7 +152,8 @@ pub fn derive_canister(input: TokenStream) -> TokenStream {
         impl #trait_name for #name {
             #[cfg(target_arch = "wasm32")]
             fn init_instance() -> Self {
-                Self { #principal_field : ::ic_cdk::export::Principal::anonymous() #state_fields_wasm #default_fields }
+                let principal = ::ic_cdk::api::id();
+                Self { #principal_field : principal #state_fields_wasm #default_fields }
             }
 
             #[cfg(not(target_arch = "wasm32"))]

--- a/ic-helpers/Cargo.toml
+++ b/ic-helpers/Cargo.toml
@@ -4,9 +4,9 @@ name = "ic-helpers"
 version = "0.2.1"
 
 [dependencies]
-dfn_core = {git = "https://github.com/infinity-swap/ic"}
-dfn_protobuf = {git = "https://github.com/infinity-swap/ic"}
-ledger-canister = {git = "https://github.com/infinity-swap/ic"}
+dfn_core = {git = "https://github.com/infinity-swap/ic", branch = "rebased-2022-02-17"}
+dfn_protobuf = {git = "https://github.com/infinity-swap/ic", branch = "rebased-2022-02-17"}
+ledger-canister = {git = "https://github.com/infinity-swap/ic", branch = "rebased-2022-02-17"}
 async-trait = "0.1"
 hex = "0.4"
 candid = "0.7"

--- a/ic-helpers/src/factory/state.rs
+++ b/ic-helpers/src/factory/state.rs
@@ -1,9 +1,9 @@
 use crate::factory::error::FactoryError;
 use crate::factory::Factory;
 use crate::ledger::LedgerPrincipalExt;
+use dfn_core::api::PrincipalId;
 use ic_cdk::export::candid::{CandidType, Deserialize, Principal};
-use ic_types::PrincipalId;
-use ledger_canister::{Subaccount, TRANSACTION_FEE};
+use ledger_canister::{Subaccount, DEFAULT_TRANSFER_FEE};
 use std::future::Future;
 use std::hash::Hash;
 use std::pin::Pin;
@@ -151,10 +151,10 @@ async fn consume_provided_icp(
         .await
         .map_err(FactoryError::LedgerError)?;
 
-    if balance < icp_fee + TRANSACTION_FEE.get_e8s() {
+    if balance < icp_fee + DEFAULT_TRANSFER_FEE.get_e8s() {
         return Err(FactoryError::NotEnoughIcp(
             balance,
-            icp_fee + TRANSACTION_FEE.get_e8s(),
+            icp_fee + DEFAULT_TRANSFER_FEE.get_e8s(),
         ));
     }
 

--- a/ic-helpers/src/ledger/principal_ext.rs
+++ b/ic-helpers/src/ledger/principal_ext.rs
@@ -1,14 +1,14 @@
 use crate::ledger::account_id::FromPrincipal;
 use async_trait::async_trait;
-use dfn_core::api::call_with_cleanup;
+use dfn_core::api::{call_with_cleanup, PrincipalId};
+use dfn_core::CanisterId;
 use dfn_protobuf::protobuf;
 use ic_cdk::export::candid::{CandidType, Principal};
-use ic_types::{CanisterId, PrincipalId};
 use ledger_canister::{
     account_identifier::{AccountIdentifier, Subaccount},
     tokens::Tokens,
     BinaryAccountBalanceArgs, BlockHeight, BlockRes, Memo, Operation as Operate, SendArgs,
-    TransferArgs, TransferError, TRANSACTION_FEE,
+    TransferArgs, TransferError, DEFAULT_TRANSFER_FEE,
 };
 
 #[derive(CandidType, Debug, PartialEq)]
@@ -177,18 +177,18 @@ impl LedgerPrincipalExt for Principal {
         from_subaccount: Option<Subaccount>,
         to_subaccount: Option<Subaccount>,
     ) -> Result<u64, String> {
-        if amount < TRANSACTION_FEE.get_e8s() {
+        if amount < DEFAULT_TRANSFER_FEE.get_e8s() {
             return Err(format!(
                 "cannot transfer tokens: amount '{}' is smaller then the fee '{}'",
                 amount,
-                TRANSACTION_FEE.get_e8s()
+                DEFAULT_TRANSFER_FEE.get_e8s()
             ));
         }
 
         let args = TransferArgs {
             memo: Default::default(),
-            amount: (Tokens::from_e8s(amount) - TRANSACTION_FEE)?,
-            fee: TRANSACTION_FEE,
+            amount: (Tokens::from_e8s(amount) - DEFAULT_TRANSFER_FEE)?,
+            fee: DEFAULT_TRANSFER_FEE,
             from_subaccount,
             to: AccountIdentifier::from_principal(to, to_subaccount).to_address(),
             created_at_time: None,

--- a/ic-helpers/src/ledger/principal_ext.rs
+++ b/ic-helpers/src/ledger/principal_ext.rs
@@ -179,7 +179,7 @@ impl LedgerPrincipalExt for Principal {
     ) -> Result<u64, String> {
         if amount < DEFAULT_TRANSFER_FEE.get_e8s() {
             return Err(format!(
-                "cannot transfer tokens: amount '{}' is smaller then the fee '{}'",
+                "cannot transfer tokens: amount '{}' is less then the fee '{}'",
                 amount,
                 DEFAULT_TRANSFER_FEE.get_e8s()
             ));


### PR DESCRIPTION
Update ic fork dependency to a more recent branch, to make it possible to use with IC. This also required a little refactoring (renaming `TRANSACTION_FEE` to `DEFAULT_TRANSFER_FEE`.

Also added better error messages for derive macro and added possibility to retrieve canister principal id from inside the canister with simple `self.principal()` call.