### PR TITLE
[NPROD-17] Fix ECDSA signing for the new ic dependencies version

### DIFF
--- a/ic-canister/ic-canister-macros/src/canister_call.rs
+++ b/ic-canister/ic-canister-macros/src/canister_call.rs
@@ -82,12 +82,7 @@ pub(crate) fn canister_notify(input: TokenStream) -> TokenStream {
     let inner_method = Ident::new(&format!("___{method}"), method.span());
     let args = normalize_args(&input.method_call.args);
     let cycles = input.cycles;
-    let cdk_call = get_cdk_notify(
-        quote! {#canister.principal()},
-        &method_name,
-        &args,
-        cycles,
-    );
+    let cdk_call = get_cdk_notify(quote! {#canister.principal()}, &method_name, &args, cycles);
 
     let expanded = quote! {
         {
@@ -210,7 +205,6 @@ pub(crate) fn virtual_canister_call(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-
 //Ok::<(), ::ic_cdk::api::call::RejectionCode>(())
 
 pub(crate) fn virtual_canister_notify(input: TokenStream) -> TokenStream {
@@ -221,12 +215,7 @@ pub(crate) fn virtual_canister_notify(input: TokenStream) -> TokenStream {
     let response_type = &input.response_type;
     let cycles = input.cycles;
 
-    let cdk_call = get_cdk_notify(
-        quote! {#principal},
-        &method_name,
-        &args,
-        cycles,
-    );
+    let cdk_call = get_cdk_notify(quote! {#principal}, &method_name, &args, cycles);
 
     let is_tuple = matches!(response_type, Type::Tuple(_));
 
@@ -273,7 +262,6 @@ pub(crate) fn virtual_canister_notify(input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-
 fn get_cdk_call(
     principal: proc_macro2::TokenStream,
     method_name: &str,
@@ -318,7 +306,6 @@ fn get_cdk_call(
     }
 }
 
-
 fn get_cdk_notify(
     principal: proc_macro2::TokenStream,
     method_name: &str,
@@ -326,13 +313,13 @@ fn get_cdk_notify(
     cycles: Option<Expr>,
 ) -> proc_macro2::TokenStream {
     if let Some(cycles) = cycles {
-        quote!{
+        quote! {
 
                 ::ic_cdk::api::call::notify_with_payment128(#principal, #method_name, (#args), #cycles)
 
         }
     } else {
-        quote!{
+        quote! {
                 ::ic_cdk::api::call::notify(#principal, #method_name, (#args))
 
         }

--- a/ic-canister/ic-canister-macros/src/lib.rs
+++ b/ic-canister/ic-canister-macros/src/lib.rs
@@ -20,17 +20,17 @@ pub fn canister_call(input: TokenStream) -> TokenStream {
 }
 
 /// Makes an inter-canister call, which sends a one-way message. This macro is the same as [`canister_call`] usage, except ignoring the reply.
-/// 
+///
 /// Returns `Ok(())` if the message was successfully enqueued, otherwise returns a reject code.
-/// 
+///
 /// ```ignore
 /// let result: Result<(), ic_cdk::api::call::RejectionCode> = canister_notify!(canister_instance.method_name(arg1, arg2), ());
 /// ```
-/// 
+///
 /// To obtain a canister instance for this call, use [`ic_canister::Canister::from_principal`] method.
 /// If the canister to be called does not implement [`ic_canister::Canister`] trait, use
 /// [`virtual_canister_notify`] macro instead.
-/// 
+///
 ///  # Notes
 ///
 ///   * The caller has no way of checking whether the destination processed the notification.

--- a/ic-canister/ic-canister/src/lib.rs
+++ b/ic-canister/ic-canister/src/lib.rs
@@ -205,7 +205,7 @@
 //! let principal = Principal::from_text("qd4yy-7yaaa-aaaag-aacdq-cai").unwrap();
 //! let result: Result<(), ic_cdk::api::call::RejectionCode>= virtual_canister_notify!(principal, "remote_method_name", (arg1, arg2), ());
 //! ```
-//! 
+//!
 //! # Testing canisters
 //!
 //! ## Internal canister logic

--- a/ic-canister/tests/canister_b/src/lib.rs
+++ b/ic-canister/tests/canister_b/src/lib.rs
@@ -1,6 +1,6 @@
 use candid::{CandidType, Deserialize, Principal};
 use canister_a::CanisterA;
-use ic_canister::{canister_call, virtual_canister_call, canister_notify, virtual_canister_notify};
+use ic_canister::{canister_call, canister_notify, virtual_canister_call, virtual_canister_notify};
 use ic_storage::stable::Versioned;
 use ic_storage::IcStorage;
 use std::cell::RefCell;
@@ -61,10 +61,12 @@ impl CanisterB {
     async fn call_increment_virtual(&self, value: u32) -> u32 {
         let mut canister_a = self.state.borrow().canister_a;
 
-        virtual_canister_call!(canister_a, "inc_counter", (value, ), ())
+        virtual_canister_call!(canister_a, "inc_counter", (value,), ())
             .await
             .unwrap();
-        virtual_canister_call!(canister_a, "get_counter", (), u32).await.unwrap()
+        virtual_canister_call!(canister_a, "get_counter", (), u32)
+            .await
+            .unwrap()
     }
 
     #[update]
@@ -80,7 +82,9 @@ impl CanisterB {
     #[allow(unused_mut)]
     #[allow(unused_variables)]
     async fn notify_increment_virtual(&self, value: u32) -> bool {
-        virtual_canister_notify!(self.state.borrow().canister_a, "inc_counter", (value, ), ()).await.unwrap();
+        virtual_canister_notify!(self.state.borrow().canister_a, "inc_counter", (value,), ())
+            .await
+            .unwrap();
         true
     }
 }
@@ -110,6 +114,5 @@ mod tests {
 
         assert_eq!(canister_b2.notify_increment(100).await, true);
         assert_eq!(canister_a2.__get_counter().await.unwrap(), 100);
-
     }
 }

--- a/ic-helpers/src/management/canister.rs
+++ b/ic-helpers/src/management/canister.rs
@@ -28,8 +28,8 @@ pub type UserID = Principal;
 pub type WasmModule = Vec<u8>;
 
 /// WARNING!!!
-/// This struct is not imported from `ic00_types` 
-/// because `dfx 0.9.3` uses older version of this struct then 
+/// This struct is not imported from `ic00_types`
+/// because `dfx 0.9.3` uses older version of this struct then
 /// the `ic-ic00-types` dependency of this crate.
 /// Code that uses this struct may not work on later versions of dfx.
 #[derive(CandidType, Deserialize, Debug)]
@@ -40,8 +40,8 @@ pub struct ECDSAPublicKeyArgs {
 }
 
 /// WARNING!!!
-/// This struct is not imported from `ic00_types` 
-/// because `dfx 0.9.3` uses older version of this struct then 
+/// This struct is not imported from `ic00_types`
+/// because `dfx 0.9.3` uses older version of this struct then
 /// the `ic-ic00-types` dependency of this crate.
 /// Code that uses this struct may not work on later versions of dfx.
 #[derive(CandidType, Deserialize, Debug)]
@@ -190,7 +190,7 @@ impl Canister {
         };
         virtual_canister_call!(
             Principal::management_canister(),
-            "ecdsa_public_key",
+            "get_ecdsa_public_key", // WARNING! This method renamed in dfx 0.10.0 to `ecdsa_public_key`
             (request,),
             ECDSAPublicKeyResponse
         )

--- a/ic-helpers/src/management/canister.rs
+++ b/ic-helpers/src/management/canister.rs
@@ -12,7 +12,7 @@ use candid::{encode_args, CandidType, Nat, Principal};
 use ic_base_types::CanisterId;
 use ic_canister::virtual_canister_call;
 use ic_cdk::api::call::RejectionCode;
-use ic_ic00_types::{ECDSAPublicKeyArgs, ECDSAPublicKeyResponse, EcdsaKeyId, SignWithECDSAReply};
+use ic_ic00_types::{ECDSAPublicKeyResponse, SignWithECDSAReply};
 use k256::elliptic_curve::AlgorithmParameters;
 use k256::pkcs8::{PublicKeyDocument, SubjectPublicKeyInfo};
 use k256::Secp256k1;
@@ -20,13 +20,36 @@ use libsecp256k1::PublicKey;
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::convert::{AsRef, From};
-use std::str::FromStr;
 
 use crate::Pubkey;
 
 pub type CanisterID = Principal;
 pub type UserID = Principal;
 pub type WasmModule = Vec<u8>;
+
+/// WARNING!!!
+/// This struct is not imported from `ic00_types` 
+/// because `dfx 0.9.3` uses older version of this struct then 
+/// the `ic-ic00-types` dependency of this crate.
+/// Code that uses this struct may not work on later versions of dfx.
+#[derive(CandidType, Deserialize, Debug)]
+pub struct ECDSAPublicKeyArgs {
+    pub canister_id: Option<CanisterId>,
+    pub derivation_path: Vec<Vec<u8>>,
+    pub key_id: String,
+}
+
+/// WARNING!!!
+/// This struct is not imported from `ic00_types` 
+/// because `dfx 0.9.3` uses older version of this struct then 
+/// the `ic-ic00-types` dependency of this crate.
+/// Code that uses this struct may not work on later versions of dfx.
+#[derive(CandidType, Deserialize, Debug)]
+pub struct SignWithECDSAArgs {
+    pub message_hash: Vec<u8>,
+    pub derivation_path: Vec<Vec<u8>>,
+    pub key_id: String,
+}
 
 #[derive(CandidType, Clone, Deserialize, Default)]
 pub struct CanisterSettings {
@@ -163,11 +186,11 @@ impl Canister {
         let request = ECDSAPublicKeyArgs {
             canister_id,
             derivation_path,
-            key_id: EcdsaKeyId::from_str("secp256k1").expect("known id"),
+            key_id: "secp256k1".into(),
         };
         virtual_canister_call!(
             Principal::management_canister(),
-            "get_ecdsa_public_key",
+            "ecdsa_public_key",
             (request,),
             ECDSAPublicKeyResponse
         )
@@ -179,8 +202,8 @@ impl Canister {
         hash: Vec<u8>,
         derivation_path: Vec<Vec<u8>>,
     ) -> Result<SignWithECDSAReply, (RejectionCode, String)> {
-        let request = ic_ic00_types::SignWithECDSAArgs {
-            key_id: EcdsaKeyId::from_str("secp256k1").expect("known id"),
+        let request = SignWithECDSAArgs {
+            key_id: "secp256k1".into(),
             message_hash: hash,
             derivation_path,
         };


### PR DESCRIPTION
The DFX 0.9.3 uses the older version of the structures for the ECDSA signing code, then defined in dependencies of `ic-helpers`.
In this PR that structures is defined to be compatible with this DFX version.